### PR TITLE
StrictMatcher added (#3)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,20 +1,21 @@
 CHANGELOG
 ---------
 
-v0.1.1 (2019-06-7)
-..................
+v0.2.0 (2019-06-09)
+...................
+* StrictMatcher added (#3)
+
+v0.1.1 (2019-06-07)
+...................
 * CI/CD config minor tweaks
 * README updated
 
-
-v0.1.0 (2019-06-7)
-..................
-
+v0.1.0 (2019-06-07)
+...................
 * YamlLoader added
 * Makefile added
 * CI/CD minimal pipeline added
 
-v0.0.1 (2019-06-7)
-..................
-
+v0.0.1 (2019-06-07)
+...................
 * Start the project

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,8 @@ Set your environment variables, add them to your YAML configuration file:
     mail:
       login: user
       password: ${MAIL_PASSWORD:-my_default_password}
+    sentry:
+      dsn: ${VAR_NOT_SET}
 
 Then load your config:
 
@@ -41,7 +43,21 @@ Then load your config:
     config = YamlLoader(path="config.yaml").load()
     print(config)
     # {'db': {'login': 'user', 'password': 'my_db_password'},
-    # 'mail': {'login': 'user', 'password': 'my_default_password'}}
+    # 'mail': {'login': 'user', 'password': 'my_default_password'},
+    # 'sentry': {'dsn': None}}
+
+You may want to discourage Bash-style envs with defaults in your configs.
+In such case, use a ``StrictMatcher``:
+
+.. code-block:: python
+
+    from piny import YamlLoader, StrictMatcher
+
+    config = YamlLoader(path="config.yaml", matcher=StrictMatcher).load()
+
+Both strict and default matchers produce ``None`` value if environment variable
+matched is not set in the system (and no default syntax used in the case of
+default matcher).
 
 
 .. |Build| image:: https://travis-ci.org/pilosus/piny.svg?branch=master

--- a/piny/loader.py
+++ b/piny/loader.py
@@ -14,7 +14,7 @@ class Matcher(yaml.SafeLoader):
     Base class for matchers (i.e. yaml loaders)
     """
 
-    matcher: Pattern[str]
+    matcher: Pattern[str] = re.compile("")
 
     @staticmethod
     def constructor(loader, node):
@@ -28,11 +28,11 @@ class StrictMatcher(Matcher):
     If value is not set return None.
     """
 
-    matcher = re.compile(r"\$\{([^}^{]+)\}")
+    matcher = re.compile(r"\$\{([^}^{^:]+)\}")
 
     @staticmethod
     def constructor(loader, node):
-        match = MatcherWithDefaults.matcher.match(node.value)
+        match = StrictMatcher.matcher.match(node.value)
         return os.environ.get(match.groups()[0])  # type: ignore
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,9 +1,10 @@
+import re
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-from piny import MatcherWithDefaults, StrictMatcher, YamlLoader
+from piny import Matcher, MatcherWithDefaults, StrictMatcher, YamlLoader
 
 #
 # Constants
@@ -25,7 +26,7 @@ CONFIG_MAP = {
 
 
 @pytest.mark.parametrize("name", ["db", "mail"])
-def test_env_loader_values_undefined(name):
+def test_strict_matcher_values_undefined(name):
     config = YamlLoader(
         path=CONF_DIR.joinpath("{}.yaml".format(name)), matcher=StrictMatcher
     ).load()
@@ -33,7 +34,7 @@ def test_env_loader_values_undefined(name):
 
 
 @pytest.mark.parametrize("name", ["db", "mail"])
-def test_env_loader_values_set(name):
+def test_strict_matcher_values_set(name):
     with mock.patch("piny.loader.StrictMatcher.constructor") as expand_mock:
         expand_mock.return_value = CONFIG_MAP[name]
         config = YamlLoader(
@@ -42,7 +43,19 @@ def test_env_loader_values_set(name):
         assert config[name]["password"] == CONFIG_MAP[name]
 
 
-def test_env_loader_defaults_values_undefined():
+def test_strict_matcher_default_do_not_matched():
+    config = YamlLoader(
+        path=CONF_DIR.joinpath("defaults.yaml"), matcher=StrictMatcher
+    ).load()
+    assert config["db"]["password"] is None
+    assert (
+        config["mail"]["password"] == "${MAIL_PASSWORD:-My123~!@#$%^&*())_+Password!}"
+    )
+    assert config["logging"]["password"] == "${LOGGING_PASSWORD:-:-test:-}"
+    assert config["sentry"]["password"] == "${SENTRY_PASSWORD:-}"
+
+
+def test_matcher_with_defaults_values_undefined():
     config = YamlLoader(
         path=CONF_DIR.joinpath("defaults.yaml"), matcher=MatcherWithDefaults
     ).load()
@@ -52,7 +65,7 @@ def test_env_loader_defaults_values_undefined():
     assert config["sentry"]["password"] == ""
 
 
-def test_env_loader_defaults_values_set():
+def test_matcher_with_defaults_values_set():
     with mock.patch("piny.loader.os.environ.get") as expand_mock:
         expand_mock.side_effect = lambda v, _: CONFIG_MAP[v.split("_")[0].lower()]
         config = YamlLoader(
@@ -62,3 +75,18 @@ def test_env_loader_defaults_values_set():
         assert config["mail"]["password"] == CONFIG_MAP["mail"]
         assert config["sentry"]["password"] == CONFIG_MAP["sentry"]
         assert config["logging"]["password"] == CONFIG_MAP["logging"]
+
+
+def test_base_matcher():
+    """
+    WATCH OUT! Black magic of Pytest in action!
+
+    When placed at the beginning of test module this test make all other tests fail.
+    Make sure this test is at the bottom!
+    """
+    with pytest.raises(NotImplementedError):
+        with mock.patch(
+            "piny.loader.Matcher.matcher", new_callable=mock.PropertyMock
+        ) as matcher_mock:
+            matcher_mock.return_value = re.compile("")
+            YamlLoader(path=CONF_DIR.joinpath("defaults.yaml"), matcher=Matcher).load()


### PR DESCRIPTION
Fix #3 

Instead of ``EnvLoader`` use ``Matcher`` class names. Otherwise, classes that match and replace envs are not distringuashable from ``YamlLoader`` class